### PR TITLE
Show 2 decimals for pp

### DIFF
--- a/osuplus.user.js
+++ b/osuplus.user.js
@@ -480,7 +480,7 @@ function makeScoreTableRow(score, rankno){
         $("<td></td>").text(rankno>0 ? "#" + rankno : ""),
         $("<td></td>").append(getRankImg(score.rank)),
         $("<td></td>").html(rankno===1 ? "<b>"+commarise(score.score)+"</b>" : commarise(score.score)),
-        $("<td></td>").text(Math.round(score.pp)),
+        $("<td></td>").text(parseFloat(score.pp).toFixed(2)),
         $("<td></td>").html(acc==100 ? "<b>"+acc.toFixed(2) + "%</b>" : acc.toFixed(2) + "%"),
         $("<td></td>").append(function(playerid, img){
             img.attr("class", "flag");


### PR DESCRIPTION
Most people prefer decimals as they're more precise than userpage listings + people are used to the older "show pp on score pages" userscript.