### PR TITLE
Remove the link to the old page to get the API key

### DIFF
--- a/osuplus.user.js
+++ b/osuplus.user.js
@@ -4185,7 +4185,7 @@
             `<div class="op-getkey">
                 <h1 id="osuplusnotice">
                     [osuplus] Click <a class="a-promptKey">here</a> to use your osu!API key.<br>
-                    Don't have API key? Get from <a href='https://osu.ppy.sh/p/api' target="_blank">here</a>
+                    Don't have API key? Get from <a href='https://osu.ppy.sh/home/account/edit#legacy-api' target="_blank">here</a>
                 </h1>
             </div>`
         );

--- a/osuplus.user.js
+++ b/osuplus.user.js
@@ -4185,7 +4185,7 @@
             `<div class="op-getkey">
                 <h1 id="osuplusnotice">
                     [osuplus] Click <a class="a-promptKey">here</a> to use your osu!API key.<br>
-                    Don't have API key? Get from <a href='https://osu.ppy.sh/p/api' target="_blank">here</a> or <a href='https://old.ppy.sh/p/api' target="_blank">here</a>
+                    Don't have API key? Get from <a href='https://osu.ppy.sh/p/api' target="_blank">here</a>
                 </h1>
             </div>`
         );


### PR DESCRIPTION
Both links redirect to the [same page](https://osu.ppy.sh/home/account/edit#legacy-api).