### PR TITLE
Better support for "osu! subdivide nations" extension

### DIFF
--- a/osuplus.user.js
+++ b/osuplus.user.js
@@ -1217,7 +1217,7 @@
 
                 //Get player list
                 var playerList = $(".ranking-page-table__row").map(function(i, ele){
-                    return $(ele).find(".ranking-page-table__user-link a").eq(1).attr("data-user-id");
+                    return $(ele).find(".ranking-page-table__user-link-text").attr("data-user-id");
                 });
                 var funs = [];
                 playerInfo = [];


### PR DESCRIPTION
when using the [osu! subdivide nations](https://github.com/Cavitedev/osu-subdivide-nations) extension, osuplus can't get the user ID for players with the extra flag because it happens to sit in an anchor `<a>` element at index 1.

so at the end the `playerInfo` array is shorter than expected and we crash at the first null element member access:
![image](https://github.com/limjeck/osuplus/assets/43873467/3064965a-f43d-4cf0-8857-1788e8a82fca)
(I trimmed off some rows at the top)

using `.ranking-page-table__user-link-text` seems better (and probably more robust in general)