### PR TITLE
Fix issue where jsonUser can't be found when lazer mode is enabled.

### DIFF
--- a/osuplus.user.js
+++ b/osuplus.user.js
@@ -1148,7 +1148,7 @@
             if($("#osuplusloaded").length) return;
             $("body").append("<a hidden id='osuplusloaded' class='osuplus'></a>");
             addCss();
-            jsonUser = JSON.parse($(".js-react.u-contents").attr("data-initial-data")).user;
+            jsonUser = JSON.parse($(".js-react.u-contents[data-initial-data]").attr("data-initial-data")).user;
             gameMode = getGameMode();
 
             addDetailedTop();


### PR DESCRIPTION
When lazer mode is enabled, there are three elements that match the ".js-react.u-contents" selector. This PR makes the selector more specific so the element that has the json data is specifically selected.